### PR TITLE
Fix ALLOW_ANONYMOUS_READ value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/view-server",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/view-server",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Serves the HTML pages for the IML GUI.",
   "main": "targetdir/bundle.js",
   "scripts": {

--- a/source/conf.js
+++ b/source/conf.js
@@ -29,7 +29,7 @@ type confT = {
 const env: confT = (process.env: any);
 
 let conf: $Shape<confT> = {
-  ALLOW_ANONYMOUS_READ: env.ALLOW_ANONYMOUS_READ,
+  ALLOW_ANONYMOUS_READ: env.ALLOW_ANONYMOUS_READ === "true",
   BUILD: env.BUILD,
   IS_RELEASE: env.IS_RELEASE,
   NODE_ENV: env.NODE_ENV || "development",


### PR DESCRIPTION
Description: env.ALLOW_ANONYMOUS_READ is either "true" or "false", so if
we check the value with something like:

```
if(conf.ALLOW_ANONYMOUS_READ)
```

it will always return true. Instead, we should check against the
environment variable value.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>